### PR TITLE
fix duplicating _prefix when extend

### DIFF
--- a/sqlalchemy_fdw/__init__.py
+++ b/sqlalchemy_fdw/__init__.py
@@ -73,7 +73,8 @@ class ForeignTable(Table):
         metadata = args[1]
         table.pgfdw_server = kwargs.pop('pgfdw_server', None)
         table.pgfdw_options = kwargs.pop('pgfdw_options', None) or {}
-        table._prefixes.append('FOREIGN')
+        if 'FOREIGN' not in table._prefixes:
+            table._prefixes.append('FOREIGN')
 
         if not hasattr(metadata, '_foreign_tables'):
             metadata._foreign_tables = {}


### PR DESCRIPTION
Given the following example:
```from sqlalchemy import create_engine, Column, TIMESTAMP, MetaData
from sqlalchemy_fdw import ForeignTable

engine = create_engine('pgfdw://postgres:postgres@localhost/postgres')

meta = MetaData(bind=engine)

def foo():
    table = ForeignTable(
                'foo', meta, Column('created_at', TIMESTAMP(timezone=True)),
                pgfdw_server='mongo', pgfdw_options={
                    'database': 'test_db',
                    'collection': 'test_collection'
                    }
                )
    table.create()


def bar():
    table = ForeignTable(
                'foo', meta, Column('created_at', TIMESTAMP(timezone=True)),
                Column('updated_at', TIMESTAMP(timezone=True)),
                pgfdw_server='mongo', pgfdw_options={
                    'database': 'test_db',
                    'collection': 'test_collection'
                    },
                extend_existing=True
                )
    table.drop(checkfirst=True)
    table.create()

foo()
bar()
```

This exception is raised:
```Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/sqlalchemy/engine/base.py", line 1182, in _execute_context
    context)
  File "/usr/local/lib/python3.5/dist-packages/sqlalchemy/engine/default.py", line 470, in do_execute
    cursor.execute(statement, parameters)
psycopg2.ProgrammingError: syntax error at or near "FOREIGN"
LINE 2: CREATE FOREIGN FOREIGN TABLE foo (
                       ^
```

This PR evalutes `'FOREIGN' not in table._prefixes` before appending the `FOREIGN` prefix when `ForeignTable.__new__` is called. This way, creating additional instances with the same table name and metadata and `extends_existing=True` don't add an additional `FOREIGN` to the compiled create statement for each instance.